### PR TITLE
Implement correction.py fields completion

### DIFF
--- a/gui/corrections.py
+++ b/gui/corrections.py
@@ -69,7 +69,10 @@ def main():
         event, values = window.read()
         print(event, values)
 
-        if event == "id_enter":
+        if event == sg.WIN_CLOSED:
+            break
+
+        elif event == "id_enter":
             db = db_session.query(PaliWord)\
                 .filter(PaliWord.id == values["id"]).first()
             summary = make_summary(db)
@@ -136,11 +139,15 @@ def main():
             save_corections_tsv(values, PTH)
             clear_all(values, window)
 
-        elif event and event.endswith("_key") and event.startswith("field"):
+        elif event.endswith("_key") and event.startswith("field"):
             _field_combo_key_action(window, values, event.rstrip("_key"))
 
-        elif event == sg.WIN_CLOSED:
-            break
+        elif event.endswith("_enter") and event.startswith("field"):
+            combo = window[event.rstrip("_enter")]
+            # Using Tkinter event
+            func = getattr(combo.widget, 'event_generate')
+            if func:
+                func('<Down>')
 
     window.close()
 

--- a/gui/corrections.py
+++ b/gui/corrections.py
@@ -26,9 +26,9 @@ def count_combo_size(values: list) -> tuple:
 COLUMN_NAMES = get_column_names()
 FIELD_COMBO_SIZE = count_combo_size(COLUMN_NAMES)
 ENABLE_LIST = \
-    [f'field{i}' for i in range(1, 4)] + \
-    [f'clear{i}' for i in range(1, 4)] + \
-    ['submit', 'clear_all']
+    [f"field{i}" for i in range(1, 4)] + \
+    [f"clear{i}" for i in range(1, 4)] + \
+    ["submit", "clear_all"]
 
 
 def _set_state(window: sg.Window, enabled=True) -> None:
@@ -54,7 +54,7 @@ def _field_combo_key_action(
             values=new_field_values,
             size=size,)
         if new_field_values:
-            combo.set_tooltip('\n'.join(new_field_values))
+            combo.set_tooltip("\n".join(new_field_values))
             _combo_width, combo_height = combo.get_size()
             tooltip = combo.TooltipObject
             tooltip.y += 1.5 * combo_height
@@ -80,12 +80,17 @@ def main():
         if event == sg.WIN_CLOSED:
             break
 
-        elif event == "id_enter":
+        if event == "id_enter":
+            id_val = values["id"]
             db = db_session.query(PaliWord)\
-                .filter(PaliWord.id == values["id"]).first()
-            summary = make_summary(db)
-            window["id_info"].update(summary)
-            _set_state(window, enabled=True)
+                .filter(PaliWord.id == id_val).first()
+            if db:
+                summary = make_summary(db)
+                window["id_info"].update(summary)
+                _set_state(window, enabled=True)
+            else:
+                _set_state(window, enabled=False)
+                sg.popup_error(f"No entry whith id {id_val}")
 
         elif event == "field1":
             val = getattr(db, values["field1"])
@@ -153,9 +158,9 @@ def main():
         elif event.endswith("_enter") and event.startswith("field"):
             combo = window[event.rstrip("_enter")]
             # Using Tkinter event
-            func = getattr(combo.widget, 'event_generate')
+            func = getattr(combo.widget, "event_generate")
             if func:
-                func('<Down>')
+                func("<Down>")
 
         elif event.endswith("_key_down") and event.startswith("field"):
             combo = window[event.rstrip("_key_down")]
@@ -165,13 +170,13 @@ def main():
 
 
 def make_window():
-    sg.theme('DarkGrey10')
+    sg.theme("DarkGrey10")
     sg.set_options(
         font=("Noto Sans", 16),
         input_text_color="darkgray",
         text_color="#00bfff",
-        window_location=(0, 0),
-        #window_location=(None, None),
+        # window_location=(0, 0),
+        window_location=(None, None),  # Default behavior
         element_padding=(0, 3),
         margins=(0, 0),
     )
@@ -294,15 +299,15 @@ def make_window():
     ]
 
     window = sg.Window(
-        'Corrections',
+        "Corrections",
         layout,
         resizable=True,
         finalize=True,
     )
 
-    window['id'].bind("<Return>", "_enter")
+    window["id"].bind("<Return>", "_enter")
     for i in range(1, 4):
-        field = f'field{i}'
+        field = f"field{i}"
         window[field].bind("<Return>", "_enter")
         window[field].bind("<Key>", "_key")
         window[field].bind("<Key-Down>", "_key_down")

--- a/gui/corrections.py
+++ b/gui/corrections.py
@@ -19,7 +19,7 @@ def get_column_names():
 
 
 def count_combo_size(values: list) -> tuple:
-    width = max(map(len, values))
+    width = max(map(len, values)) + 1
     return (width, 0)
 
 

--- a/gui/corrections.py
+++ b/gui/corrections.py
@@ -226,8 +226,7 @@ def make_window():
                 key="field3",
                 enable_events=True,
                 size=FIELD_COMBO_SIZE),
-            sg.Button(
-                "Clear", key="clear1", font=(None, 13)),
+            sg.Button("Clear", key="clear3", font=(None, 13)),
             sg.Text("", size=(22, 1)),
             sg.Input(key="bold", size=(30, 1)),
             sg.Button("Bold", key="bold_button", font=(None, 13)),

--- a/gui/corrections.py
+++ b/gui/corrections.py
@@ -30,7 +30,6 @@ ENABLE_LIST = \
     [f'clear{i}' for i in range(1, 4)] + \
     ['submit', 'clear_all']
 
-print(ENABLE_LIST)
 
 def _set_state(window: sg.Window, enabled=True) -> None:
     for i in ENABLE_LIST:
@@ -54,8 +53,17 @@ def _field_combo_key_action(
             value=search,
             values=new_field_values,
             size=size,)
+        if new_field_values:
+            combo.set_tooltip('\n'.join(new_field_values))
+            _combo_width, combo_height = combo.get_size()
+            tooltip = combo.TooltipObject
+            tooltip.y += 1.5 * combo_height
+            tooltip.showtip()
+        else:
+            combo.set_tooltip(None)
     else:
         _reset_field_combo(window, field_key)
+        combo.set_tooltip(None)
 
 
 def main():
@@ -148,6 +156,10 @@ def main():
             func = getattr(combo.widget, 'event_generate')
             if func:
                 func('<Down>')
+
+        elif event.endswith("_key_down") and event.startswith("field"):
+            combo = window[event.rstrip("_key_down")]
+            combo.set_tooltip(None)
 
     window.close()
 
@@ -289,12 +301,11 @@ def make_window():
     )
 
     window['id'].bind("<Return>", "_enter")
-    window['field1'].bind("<Return>", "_enter")
-    window['field1'].bind("<Key>", "_key")
-    window['field2'].bind("<Return>", "_enter")
-    window['field2'].bind("<Key>", "_key")
-    window['field3'].bind("<Return>", "_enter")
-    window['field3'].bind("<Key>", "_key")
+    for i in range(1, 4):
+        field = f'field{i}'
+        window[field].bind("<Return>", "_enter")
+        window[field].bind("<Key>", "_key")
+        window[field].bind("<Key-Down>", "_key_down")
 
     return window
 


### PR DESCRIPTION
- When typing in `filed1`, `field2`, `field3` combo lists, there is a prompt with matching variants. `<Enter>` or `<Down>` to open list and select.
- Fix `clean3` button key.
- Add some errors handling to prevent crashes.

Also there is `if ... elif ... elif ...` instead `if ... if ... if ...` for event check in the mainloop because it is more efficient (in such a way comparing stopped after a first match).