### PR TITLE
titipaka-xml submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ gui/icons/
 gui/stash/
 gui/window_layout.py
 resources/thai_mahachula/
-resources/tipitaka-xml
 sandhi.zip
 sandhi/assets/
 sandhi/output_do/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "resources/tipitaka-xml"]
+	path = resources/tipitaka-xml
+	url = https://github.com/vipassanatech/tipitaka-xml
+	ignore = untracked

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Building the DB
 1. Download this repo
-2. Download https://github.com/VipassanaTech/tipitaka-xml into the `/resources` folder
+2. Get [tipitaka-xml](https://github.com/VipassanaTech/tipitaka-xml) with `git
+   submodule init && git submodule update` commands
 3. Install [nodejs](https://nodejs.org/en/download) 
 4. Install [poetry](https://python-poetry.org/docs/)
 5. `poetry install`


### PR DESCRIPTION
Make `resources/tipitaka-xml/` dir a [git repo submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules).

Pros:
  - Fix `tipitaka-xml` version
  - Get and update `tipitaka-xml` with `git submodule update` command (See README.md)

To up the tipitaka-xml version just go to `resources/tipitaka-xml/`, do `git pull` and optionally checkout the ref, than step back to `dpd-db` root, make `git add resources/tipitaka-xml/` and commit.