### PR TITLE
pass superscripter as binding to templates

### DIFF
--- a/exporter/export_dpd.py
+++ b/exporter/export_dpd.py
@@ -37,6 +37,7 @@ from tools.tic_toc import bip, bop
 from tools.configger import config_test
 from tools.sandhi_contraction import SandhiContractions
 from tools.utils import RenderResult, RenderedSizes, default_rendered_sizes, list_into_batches, sum_rendered_sizes
+from tools.superscripter import superscripter_uni
 
 class PaliWordTemplates:
     def __init__(self, pth: ProjectPaths):
@@ -674,6 +675,7 @@ def render_family_compound_templ(
             family_compound_templ.render(
                 i=i,
                 fc=fc,
+                superscripter_uni=superscripter_uni,
                 today=TODAY))
     else:
         return ""
@@ -696,6 +698,7 @@ def render_family_set_templ(
                 family_set_templ.render(
                     i=i,
                     fs=fs,
+                    superscripter_uni=superscripter_uni,
                     today=TODAY))
         else:
             return ""

--- a/exporter/templates/dpd_family_compound.html
+++ b/exporter/templates/dpd_family_compound.html
@@ -1,7 +1,3 @@
-<%!
-    from tools.superscripter import superscripter_uni
-%>
-
 <div id="compound_family_${i.pali_1_}" class="content hidden">
 % if " " in i.family_compound:
     <p id="${i.pali_1_}cf_top" class="heading">jump to: 

--- a/exporter/templates/dpd_family_set.html
+++ b/exporter/templates/dpd_family_set.html
@@ -1,6 +1,3 @@
-<%!
-    from tools.superscripter import superscripter_uni
-%>
 <div id="set_family_${i.pali_1_}" class="content hidden">
 % if ";" in i.family_set:
     <p id="${i.pali_1_}set_top" class="heading">jump to: 


### PR DESCRIPTION
Instead of importing with inline Python in the template, the function can be passed as an argument.

This fixes the superscripter module not being discovered by pyinstaller and erroring out compiled executables in which this template is used.