### PR TITLE
generate mdd assets file: folder  exporter\goldendict\css + icon + javascript

### DIFF
--- a/exporter/goldendict/mdict_exporter.py
+++ b/exporter/goldendict/mdict_exporter.py
@@ -7,7 +7,35 @@ from rich import print
 from typing import List, Dict
 from tools.tic_toc import bip, bop
 from tools.writemdict.writemdict import MDictWriter
+from pathlib import Path
 
+
+
+def get_all_files(directory):
+    """ recursively get all files and create a list with the format (file_path, file_content_binary)"""
+    files_list = []
+    # Create a Path object for the directory
+    base_path = Path(directory)
+    # Iterate over all files in the directory recursively
+    for file_path in base_path.rglob('*'):
+        if file_path.is_file():  # Make sure it's a file
+            # Read the content of the file as bytes
+            with open(file_path, 'rb') as file:
+                file_content = file.read()
+
+            # Get the relative file path (relative to the base directory)
+            relative_file_path = file_path.relative_to(base_path)
+            # mdd files expect the path to start with \ (windows) or /
+            #  possible workaround (if this is a problem): <img src'../img.jpg'> and dont preppend a pathseparator
+            file = '\\'+str(relative_file_path)
+            # windows: goldendict will not display a linux path (path separator: /),
+            #  but linux programms will display when path separator is \
+            #  => transform all / to  \
+            file = file.replace('/', r'\\')
+            # Append the tuple to the list with either text or binary content
+            files_list.append((file, file_content))
+
+    return files_list
 
 def mdict_synonyms(all_items, item):
     all_items.append((item['word'], item['definition_html']))
@@ -50,3 +78,18 @@ def export_to_mdict(data_list: List[Dict], pth, description, title) -> None:
     writer.write(outfile)
     outfile.close()
     print(bop())
+
+
+    # create assets mdd file, adding all files in the folder 'assets/' (recursively)
+    assets = get_all_files('exporter/goldendict/css/')
+    assets += get_all_files('exporter/goldendict/javascript/')
+    assets += get_all_files('exporter/goldendict/icon/')
+    writer = MDictWriter(
+        assets,
+        title=title,
+        description=description,
+        is_mdd=True)
+    # write the assets .mdd file
+    with open(pth.mdict_mdx_path[:-1]+'d', "wb") as outfile:
+        writer.write(outfile)
+


### PR DESCRIPTION
hello,
here a possible way to create a .mdd asset file. it adds all files and folders from a given folder recursively.

(i added 3 folders because i didnt want to mess up the folder structure.)

to link the css file css/dpd.css you would write <link rel="stylesheet" href="dpd.css" /> at the moment, because i called get_all_files('exporter/goldendict/css/'). i do not know how you want to structure the mdd file so this is just a proof of concept. 
(or ` <img src='android-chrome-512x512.png'> ` )

for example if you put the css+icon folder into an assets folder and call get_all_files('exporter/goldendict/assets/'), than the path would be  <link rel="stylesheet" href="css/dpd.css" />

i tested it in the dpd-exporter repository (it worked) and than copy pasted it her, because i still had the pickle data you send last time. i think it should work :-)

if it doesnt, please send me a pickle of the data_list: List[Dict] object that is passed to export_to_mdict() (maybe not the whole one, just a view mb are enough) for testing, and i will be able to troubleshoot.