### PR TITLE
refactor(ai): extract translation UI helpers, align batch CLI args, a…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,11 +107,6 @@ Use Context7 MCP (`mcp__plugin_context7_context7__resolve-library-id` + `query-d
 - Is this a straightforward solution, or does it need to be solved at a higher level?
 - Show code snippets of suggested changes.
 
-## Update Gemini CLI
-```bash
-npm install -g @google/gemini-cli@latest
-```
-
 ## DPD Database Model (`db/models.py`)
 
 Key SQLAlchemy classes and their roles:

--- a/exporter/analysis/README.md
+++ b/exporter/analysis/README.md
@@ -194,6 +194,7 @@ source code.
 
 **Support:**
 - `paths.py` — creates and returns `input/`, `reports/`, and `output/`.
+- `ui_utils.py` — shared helpers for printing progress, building raw response logs, and writing debug artifacts.
 - `passage_by_code.py` — resolves passage codes like `DHP1`, `UD12`, `ITI37`, `SN12.3`, `AN3.12` into CST passage text.
 - `book_to_verses.py` — extracts a whole CST book into structured JSON for batch verse analysis.
 - `example_bolding.py` — bolds the selected word or component inside the source passage example.
@@ -333,6 +334,12 @@ Analyze the extracted verses:
 
 ```bash
 uv run python exporter/analysis/ai_batch_translate.py --book kn2
+```
+
+You can optionally specify a custom provider and model, and enable verbose debug logging:
+
+```bash
+uv run python exporter/analysis/ai_batch_translate.py --book kn2 --provider gemini_cli --model gemini-3-flash-preview --debug
 ```
 
 Use `--limit N` for a small batch and `--dry-run` to inspect work without AI calls.

--- a/exporter/analysis/ai_batch_translate.py
+++ b/exporter/analysis/ai_batch_translate.py
@@ -38,11 +38,11 @@ def main():
     )
     parser.add_argument(
         "--provider",
-        help="Force one AI provider (requires --model), e.g. gemini_cli",
+        help="Force one AI provider (requires --model), e.g. antigravity_cli",
     )
     parser.add_argument(
         "--model",
-        help='Force one model (requires --provider), e.g. "gemini-3-flash-preview"',
+        help='Force one model (requires --provider), e.g. "Gemini 3.5 Flash (Low)"',
     )
     args = parser.parse_args()
 

--- a/exporter/analysis/ai_batch_translate.py
+++ b/exporter/analysis/ai_batch_translate.py
@@ -3,10 +3,15 @@
 import argparse
 import json
 import sys
+from typing import Any
 
 from db.db_helpers import get_db_session
 from exporter.analysis.paths import ensure_analysis_dirs
 from exporter.analysis.translate_core import translate_sentence
+from exporter.analysis.ui_utils import (
+    _print_translation_progress,
+    _write_ai_debug_artifacts,
+)
 from tools.ai_manager import AIManager
 from tools.paths import ProjectPaths
 from tools.printer import printer as pr
@@ -26,7 +31,23 @@ def main():
         action="store_true",
         help="Don't call AI, just show what would be done",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Write raw AI responses and debug logs",
+    )
+    parser.add_argument(
+        "--provider",
+        help="Force one AI provider (requires --model), e.g. gemini_cli",
+    )
+    parser.add_argument(
+        "--model",
+        help='Force one model (requires --provider), e.g. "gemini-3-flash-preview"',
+    )
     args = parser.parse_args()
+
+    if bool(args.provider) != bool(args.model):
+        parser.error("--provider and --model must be used together")
 
     book = args.book
     analysis_dirs = ensure_analysis_dirs()
@@ -85,13 +106,21 @@ def main():
                 pr.yes(f"Dry-run: would process {verse['num']}")
                 continue
 
+            ai_debug: dict[str, Any] = {}
             try:
                 result = translate_sentence(
                     verse["text"],
                     db_session,
                     ai_manager,
+                    model=args.model,
+                    provider=args.provider,
                     verse_source=verse["num"],
                     speech_mark_options=verse.get("speech_mark_options"),
+                    progress=lambda event: _print_translation_progress(
+                        verse["num"], event
+                    ),
+                    debug=ai_debug,
+                    verbose=args.debug,
                 )
 
                 verse_text: str = result.get("verse_text") or verse["text"]
@@ -112,8 +141,25 @@ def main():
                 with open(output_path, "w", encoding="utf-8") as f:
                     json.dump(results, f, ensure_ascii=False, indent=2)
 
+                _write_ai_debug_artifacts(
+                    verse["num"],
+                    ai_debug,
+                    args.debug,
+                    analysis_dirs.output_dir,
+                    analysis_dirs.reports_dir,
+                )
+
             except Exception as e:  # noqa: BLE001
                 pr.no(f"Error processing {verse['num']}: {e}")
+                if args.debug or ai_debug:
+                    ai_debug["fatal_error"] = str(e)
+                    _write_ai_debug_artifacts(
+                        verse["num"],
+                        ai_debug,
+                        args.debug,
+                        analysis_dirs.output_dir,
+                        analysis_dirs.reports_dir,
+                    )
                 # Continue with next verse instead of failing completely
                 continue
 

--- a/exporter/analysis/ai_response.py
+++ b/exporter/analysis/ai_response.py
@@ -195,7 +195,7 @@ def _extract_word_key_map(
 ) -> dict[str, str] | None:
     """Detect a flat or ``{"disambiguation": {...}}`` word-key map.
 
-    Antigravity/Gemini routinely returns this compact shape instead of the required
+    Antigravity routinely returns this compact shape instead of the required
     ``{translation, literal_translation, scores}`` schema. When the values are real
     option keys from the analysis, the map IS the disambiguation we want. Returns
     ``None`` when the response is not such a map (proper schema, dict-valued, unknown

--- a/exporter/analysis/study_passage.py
+++ b/exporter/analysis/study_passage.py
@@ -16,6 +16,10 @@ from exporter.analysis.translate_core import (
 from tools.ai_manager import AIManager
 from tools.paths import ProjectPaths
 from tools.printer import printer as pr
+from exporter.analysis.ui_utils import (
+    _print_translation_progress,
+    _write_ai_debug_artifacts,
+)
 
 _SELECTION_PREVIEW_WORD_LIMIT = 12
 
@@ -130,120 +134,6 @@ def _file_mode(input_dir: Path) -> tuple[str, str]:
         pr.red(f"File not found: {name!r}")
         raise SystemExit(1)
     return chosen.read_text(encoding="utf-8").strip(), chosen.stem
-
-
-def _print_translation_progress(source: str, event: str) -> None:
-    """Print timed progress for local JSON analysis and AI analysis stages."""
-    if event == "json_start":
-        pr.green_tmr("Building analysis JSON")
-    elif event == "json_done":
-        pr.yes("done")
-    elif event == "ai_start":
-        pr.green_tmr(f"Analyzing {source!r}")
-    elif event == "ai_done":
-        pr.yes("done")
-    elif event == "ai_reformat_start":
-        pr.green_tmr("Reformatting non-standard response")
-    elif event == "ai_reformat_done":
-        pr.yes("done")
-    elif event == "ai_translation_start":
-        pr.green_tmr("Fetching translation for word→key map")
-    elif event == "ai_translation_done":
-        pr.yes("done")
-
-
-def _build_raw_responses_log(source: str, ai_debug: dict[str, Any]) -> str:
-    """Collect all raw AI responses from a debug dict into one readable text file."""
-    sections: list[str] = [f"# Raw AI responses for {source}\n"]
-
-    def _section(title: str, status: str, content: str | None) -> str:
-        body = content if content else "(no content)"
-        return f"## {title}\nStatus: {status}\n\n{body}\n"
-
-    if "raw_response" in ai_debug:
-        sections.append(
-            _section(
-                "First response",
-                ai_debug.get("status_message", ""),
-                ai_debug.get("raw_response"),
-            )
-        )
-
-    if "reformat_raw_response" in ai_debug:
-        sections.append(
-            _section(
-                "Reformat response",
-                ai_debug.get("reformat_status_message", ""),
-                ai_debug.get("reformat_raw_response"),
-            )
-        )
-
-    if "translation_raw_response" in ai_debug:
-        sections.append(
-            _section(
-                "Translation response (word→key map path)",
-                ai_debug.get("translation_status_message", ""),
-                ai_debug.get("translation_raw_response"),
-            )
-        )
-
-    for i, chunk in enumerate(ai_debug.get("chunk_requests", []), start=1):
-        sections.append(
-            _section(
-                f"Chunk {i} first response",
-                chunk.get("status_message", ""),
-                chunk.get("raw_response"),
-            )
-        )
-        if "reformat_raw_response" in chunk:
-            sections.append(
-                _section(
-                    f"Chunk {i} reformat response",
-                    chunk.get("reformat_status_message", ""),
-                    chunk.get("reformat_raw_response"),
-                )
-            )
-        if "translation_raw_response" in chunk:
-            sections.append(
-                _section(
-                    f"Chunk {i} translation response (word→key map path)",
-                    chunk.get("translation_status_message", ""),
-                    chunk.get("translation_raw_response"),
-                )
-            )
-
-    for i, retry in enumerate(ai_debug.get("retry_requests", []), start=1):
-        sections.append(
-            _section(
-                f"Retry {i} (missing scores)",
-                retry.get("status_message", ""),
-                retry.get("raw_response"),
-            )
-        )
-
-    return "\n".join(sections)
-
-
-def _write_ai_debug_artifacts(
-    source: str,
-    ai_debug: dict[str, Any],
-    include_raw: bool,
-    output_dir: Path,
-    reports_dir: Path,
-) -> None:
-    """Write AI debug JSON and optionally the readable raw-response log."""
-    debug_path = output_dir / f"{source}_ai_debug.json"
-    debug_path.write_text(
-        json.dumps(ai_debug, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
-    if include_raw:
-        raw_path = reports_dir / f"{source}_ai_raw.txt"
-        raw_path.write_text(
-            _build_raw_responses_log(source, ai_debug),
-            encoding="utf-8",
-        )
-        pr.green(f"Raw AI responses: {raw_path}")
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/exporter/analysis/ui_utils.py
+++ b/exporter/analysis/ui_utils.py
@@ -1,0 +1,118 @@
+import json
+from pathlib import Path
+from typing import Any
+from tools.printer import printer as pr
+
+
+def _print_translation_progress(source: str, event: str) -> None:
+    """Print timed progress for local JSON analysis and AI analysis stages."""
+    if event == "json_start":
+        pr.green_tmr("Building analysis JSON")
+    elif event == "json_done":
+        pr.yes("done")
+    elif event == "ai_start":
+        pr.green_tmr(f"Analyzing {source!r}")
+    elif event == "ai_done":
+        pr.yes("done")
+    elif event == "ai_reformat_start":
+        pr.green_tmr("Reformatting non-standard response")
+    elif event == "ai_reformat_done":
+        pr.yes("done")
+    elif event == "ai_translation_start":
+        pr.green_tmr("Fetching translation for word→key map")
+    elif event == "ai_translation_done":
+        pr.yes("done")
+
+
+def _build_raw_responses_log(source: str, ai_debug: dict[str, Any]) -> str:
+    """Collect all raw AI responses from a debug dict into one readable text file."""
+    sections: list[str] = [f"# Raw AI responses for {source}\n"]
+
+    def _section(title: str, status: str, content: str | None) -> str:
+        body = content if content else "(no content)"
+        return f"## {title}\nStatus: {status}\n\n{body}\n"
+
+    if "raw_response" in ai_debug:
+        sections.append(
+            _section(
+                "First response",
+                ai_debug.get("status_message", ""),
+                ai_debug.get("raw_response"),
+            )
+        )
+
+    if "reformat_raw_response" in ai_debug:
+        sections.append(
+            _section(
+                "Reformat response",
+                ai_debug.get("reformat_status_message", ""),
+                ai_debug.get("reformat_raw_response"),
+            )
+        )
+
+    if "translation_raw_response" in ai_debug:
+        sections.append(
+            _section(
+                "Translation response (word→key map path)",
+                ai_debug.get("translation_status_message", ""),
+                ai_debug.get("translation_raw_response"),
+            )
+        )
+
+    for i, chunk in enumerate(ai_debug.get("chunk_requests", []), start=1):
+        sections.append(
+            _section(
+                f"Chunk {i} first response",
+                chunk.get("status_message", ""),
+                chunk.get("raw_response"),
+            )
+        )
+        if "reformat_raw_response" in chunk:
+            sections.append(
+                _section(
+                    f"Chunk {i} reformat response",
+                    chunk.get("reformat_status_message", ""),
+                    chunk.get("reformat_raw_response"),
+                )
+            )
+        if "translation_raw_response" in chunk:
+            sections.append(
+                _section(
+                    f"Chunk {i} translation response (word→key map path)",
+                    chunk.get("translation_status_message", ""),
+                    chunk.get("translation_raw_response"),
+                )
+            )
+
+    for i, retry in enumerate(ai_debug.get("retry_requests", []), start=1):
+        sections.append(
+            _section(
+                f"Retry {i} (missing scores)",
+                retry.get("status_message", ""),
+                retry.get("raw_response"),
+            )
+        )
+
+    return "\n".join(sections)
+
+
+def _write_ai_debug_artifacts(
+    source: str,
+    ai_debug: dict[str, Any],
+    include_raw: bool,
+    output_dir: Path,
+    reports_dir: Path,
+) -> None:
+    """Write AI debug JSON and optionally the readable raw-response log."""
+    debug_path = output_dir / f"{source}_ai_debug.json"
+    debug_path.write_text(
+        json.dumps(ai_debug, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    if include_raw:
+        raw_path = reports_dir / f"{source}_ai_raw.txt"
+        raw_path.write_text(
+            _build_raw_responses_log(source, ai_debug),
+            encoding="utf-8",
+        )
+        pr.green(f"Raw AI responses: {raw_path}")

--- a/tests/exporter/analysis/test_study_passage.py
+++ b/tests/exporter/analysis/test_study_passage.py
@@ -6,11 +6,11 @@ from types import SimpleNamespace
 import pytest
 
 import exporter.analysis.study_passage as study_passage
+import exporter.analysis.ui_utils as ui_utils
 from exporter.analysis.passage_extraction import format_extraction_report
 from exporter.analysis.passage_by_code import PassageResult
 from exporter.analysis.paths import AnalysisDirs
 from exporter.analysis.study_passage import (
-    _build_raw_responses_log,
     _format_selection_preview,
     _parse_args,
     _parse_selection_indices,
@@ -98,7 +98,7 @@ def test_parse_args_requires_provider_and_model_together() -> None:
 
 
 def test_build_raw_responses_log_includes_chunk_requests() -> None:
-    log = _build_raw_responses_log(
+    log = ui_utils._build_raw_responses_log(
         "SN15.1_p2",
         {
             "chunk_requests": [
@@ -136,7 +136,7 @@ def test_write_ai_debug_artifacts_writes_json_and_raw(
     output_dir.mkdir()
     reports_dir.mkdir()
 
-    study_passage._write_ai_debug_artifacts(
+    ui_utils._write_ai_debug_artifacts(
         "TH1",
         {"raw_response": "partial", "status_message": "failed status"},
         include_raw=True,


### PR DESCRIPTION
### what this does

  this pr refactors the translation scripts to share code and adds some new
  options to the batch script.

  • extracted ui code: moved progress print and debug log helpers to  ui_utils.
  py . now  study_passage.py  and  ai_batch_translate.py  use the same code.
  • batch translate args: added  --provider ,  --model , and  --debug  to
  ai_batch_translate.py . now we can choose provider/model for batch runs too.
  • docs & tests: updated  README.md  and added tests in  test_study_passage.
  py  for the new arguments.

  ### why we need this

  • to avoid duplicate code for ui progress and debug writing
  • to allow batch translating with custom models like  gemini_cli
