### PR TITLE
fix(extension): popout freezes in dark theme (infinite MutationObserver loop)

### DIFF
--- a/exporter/wxt_extension/entrypoints/popout/main.ts
+++ b/exporter/wxt_extension/entrypoints/popout/main.ts
@@ -40,13 +40,20 @@ if (logoTip) {
 }
 
 // The popout should never show the minimized sliver, regardless of the saved setting.
-const unminimize = () => panelEl?.classList.remove('dpd-minimized');
+// NOTE: the observer must (a) only act when the class is actually present and
+// (b) disconnect while removing it. An unconditional classList.remove() rewrites the
+// class attribute even when the token is absent, which queues another 'attributes'
+// mutation and re-invokes this callback — an infinite microtask loop that froze the
+// popout (it was tripped by applyTheme() toggling the "dark-mode" class).
 if (panelEl) {
-  new MutationObserver(unminimize).observe(panelEl, {
-    attributes: true,
-    attributeFilter: ['class'],
+  const mo = new MutationObserver(() => {
+    if (!panelEl.classList.contains('dpd-minimized')) return;
+    mo.disconnect();
+    panelEl.classList.remove('dpd-minimized');
+    mo.observe(panelEl, { attributes: true, attributeFilter: ['class'] });
   });
-  unminimize();
+  mo.observe(panelEl, { attributes: true, attributeFilter: ['class'] });
+  panelEl.classList.remove('dpd-minimized');
 }
 
 applyTheme(themeKey);


### PR DESCRIPTION
# Fix: popout window freezes in dark theme (infinite MutationObserver loop)

**Repo:** digitalpalidictionary/dpd-db · **Path:** `exporter/wxt_extension/entrypoints/popout/main.ts` · **Branch:** `fix/popout-dark-theme-freeze`

## Symptom
Opening the detached popout window on a **dark-themed** site (e.g. `s.4nt.org` in dark mode) produces a blank window with a frozen loading spinner — the entry never loads and the window is unresponsive. Light themes work fine. Reproduces on **both Chrome and Brave** (it is not browser-specific, despite first appearances).

## Root cause
The popout's "never show the minimized sliver" observer:

```js
const unminimize = () => panelEl?.classList.remove('dpd-minimized');
new MutationObserver(unminimize).observe(panelEl, { attributes: true, attributeFilter: ['class'] });
unminimize();
```

`DOMTokenList.remove()` rewrites the `class` attribute **even when the token is absent**, which queues another `attributes` mutation → re-invokes the observer → `remove()` again → an **infinite synchronous microtask loop** that pegs the main thread during first render (before the fetch can resolve, hence the frozen spinner).

It stays dormant until something toggles a class on the panel. `applyTheme()` does exactly that with the `dark-mode` class (`panelEl.classList.toggle("dark-mode", isDarkTheme)`), so the loop only fires for dark themes. Light-theme loads happen not to trip it.

## How it was confirmed
Attaching the debugger to the frozen window and issuing `Debugger.pause` broke inside the minified `unminimize` callback (single frame, no caller — i.e. an observer-driven self-loop). A light-vs-dark probe showed the JS thread `ALIVE` for `s4nt_light` and `FROZEN` (couldn't even evaluate `1+1`) for `s4nt_dark`.

## Fix
Only act when the class is actually present, and disconnect while removing so the removal can't re-trigger the callback:

```js
if (panelEl) {
  const mo = new MutationObserver(() => {
    if (!panelEl.classList.contains('dpd-minimized')) return;
    mo.disconnect();
    panelEl.classList.remove('dpd-minimized');
    mo.observe(panelEl, { attributes: true, attributeFilter: ['class'] });
  });
  mo.observe(panelEl, { attributes: true, attributeFilter: ['class'] });
  panelEl.classList.remove('dpd-minimized');
}
```

## Verification
Rebuilt (`npm run build:chrome`) and loaded unpacked in Brave. Popout now renders the entry correctly in **both** `s4nt_light` and `s4nt_dark` (and generically for any theme, since the loop is gone). No other behavior change; the service-worker fetch path is untouched.

## Impact
Affects every Chrome Web Store user who pops out the dictionary on a dark-themed page. One-file change, +12/−5.

---
Related to #253.
