### PR TITLE
Add s.4nt.org to AUTO_DOMAINS

### DIFF
--- a/exporter/wxt_extension/utils/domains.ts
+++ b/exporter/wxt_extension/utils/domains.ts
@@ -8,6 +8,7 @@ export const AUTO_DOMAINS = [
   "tipitaka.lk",
   "open.tipitaka.lk",
   "tipitaka.paauksociety.org",
+  "s.4nt.org",
 ];
 
 export const EXCLUDE_DOMAINS = [


### PR DESCRIPTION
## What

Adds `s.4nt.org` to `AUTO_DOMAINS` in `exporter/wxt_extension/utils/domains.ts`, so the DPD browser extension auto-activates there like it already does on SuttaCentral, tipitaka.org, DPR, etc.

## Why

[s.4nt.org](https://s.4nt.org) ("Suttas, Side by Side" — the debabel project) is a Pāḷi sutta-reading site that shows up to six translations side by side with the **segment-aligned Pāḷi** text on every page. That makes it exactly the kind of page DPD's double-click lookups are built for, but because the domain isn't on the auto-activate list, DPD stays dormant there and readers have to enable it per-site by hand.

## Change

One entry appended to `AUTO_DOMAINS` (matches the host and any subdomain via the existing `isAutoDomain` logic). No behavior change for any other site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)