### PR TITLE
fix(extension): make the popout one-per-site and keep every tab in sync

### DIFF
--- a/exporter/wxt_extension/entrypoints/background.ts
+++ b/exporter/wxt_extension/entrypoints/background.ts
@@ -59,6 +59,23 @@ export default defineBackground(() => {
 
     try {
       const domain = new URL(tab.url).hostname;
+
+      // If this site is already popped out, its in-page panel is intentionally hidden,
+      // so a plain toggle would look like it did nothing. Bring the popout to the front
+      // instead — that's the visible DPD for this site. (Stale flag → fall through.)
+      const hostKey = `popout_host_${domain}`;
+      const winId = (await browser.storage.local.get(hostKey) as LocalStorage)[hostKey];
+      if (winId != null) {
+        try {
+          await browser.windows.get(winId);
+          await browser.windows.update(winId, { focused: true });
+          return;
+        } catch (e) {
+          await browser.storage.local.remove(hostKey);
+          await browser.storage.session.remove(`popout_win_${winId}`);
+        }
+      }
+
       const currentState = await getDomainState(tab.url);
       const nextState = currentState === "ON" ? "OFF" : "ON";
       
@@ -108,10 +125,28 @@ export default defineBackground(() => {
     }
 
     if (request.action === "started" && sender.tab?.id) {
-      await updateIcon(sender.tab.id, "ON");
-      // Hand the content script its own tab id so it can stamp forwarded popout
-      // selections, letting each popout ignore selections from other tabs.
-      return { tabId: sender.tab.id };
+      const tabId = sender.tab.id;
+      await updateIcon(tabId, "ON");
+      // Is this SITE already popped out (from any tab)? If so, tell this freshly-loaded
+      // content script to keep its in-page panel hidden rather than show a duplicate.
+      // Validate the window is still open so a stale flag (window closed while the
+      // service worker slept) can't wrongly hide us — and clear it if dead.
+      let poppedOut = false;
+      try {
+        const host = sender.url ? new URL(sender.url).hostname : "";
+        if (host) {
+          const hostKey = `popout_host_${host}`;
+          const winId = (await browser.storage.local.get(hostKey) as LocalStorage)[hostKey];
+          if (winId != null) {
+            try { await browser.windows.get(winId); poppedOut = true; }
+            catch {
+              await browser.storage.local.remove(hostKey);
+              await browser.storage.session.remove(`popout_win_${winId}`);
+            }
+          }
+        }
+      } catch (e) { /* leave poppedOut false */ }
+      return { tabId, poppedOut };
     }
     
     if (request.action === "fetchData" && request.endpoint) {
@@ -132,17 +167,39 @@ export default defineBackground(() => {
     // Detach the dictionary into its own popup window and hide the in-page panel.
     if (request.action === "openPopout") {
       const sourceTabId = sender.tab?.id;
-      if (sourceTabId == null) return;
+      if (sourceTabId == null || !sender.url) return;
+      let host: string;
+      try { host = new URL(sender.url).hostname; } catch (e) { return; }
+
+      // One popout per SITE. Tab ids are ephemeral (close+reopen a tab and the old id is
+      // gone), which let popouts breed; keying on hostname and validating the window is
+      // still open means a site has at most one popout, reused across tabs and reloads.
+      const hostKey = `popout_host_${host}`;
+      const existingWin = (await browser.storage.local.get(hostKey) as LocalStorage)[hostKey];
+      if (existingWin != null) {
+        try {
+          await browser.windows.get(existingWin);                       // throws if closed
+          browser.windows.update(existingWin, { focused: true }).catch(() => {});
+          return;                                                       // flag already hides all tabs
+        } catch (e) {
+          await browser.storage.local.remove(hostKey);                  // stale → fall through
+          await browser.storage.session.remove(`popout_win_${existingWin}`);
+        }
+      }
+
       const url =
         (browser.runtime as any).getURL("popout.html") +
         "?q=" + encodeURIComponent(request.q || "") +
         "&theme=" + encodeURIComponent(request.theme || "auto") +
-        "&tab=" + sourceTabId;
+        "&host=" + encodeURIComponent(host);
       const win = await browser.windows.create({ url, type: "popup", width: 480, height: 820 });
       if (win?.id != null) {
-        // Remember which tab this popout belongs to, so closing it acts on that panel.
-        await browser.storage.session.set({ [`popout_win_${win.id}`]: sourceTabId });
-        browser.tabs.sendMessage(sourceTabId, { action: "dpdHidePanel" }).catch(() => {});
+        // popout_host_<host> lives in LOCAL storage so EVERY open tab of this site sees
+        // the change (content scripts get storage.local events; session ones they don't)
+        // and hides its in-page panel — not just the source tab. window id -> {host, tab}
+        // stays background-only in session (cleanup + which panel to restore/dismiss).
+        await browser.storage.local.set({ [hostKey]: win.id });
+        await browser.storage.session.set({ [`popout_win_${win.id}`]: { host, tab: sourceTabId } });
       }
       return;
     }
@@ -159,17 +216,19 @@ export default defineBackground(() => {
     }
   });
 
-  const dismissOnTab = async (tabId: number) => {
+  const dismissOnTab = async (tabId: number, host?: string) => {
     // Faithfully "turn DPD off" on this page: clear popped-out state, remove the
-    // in-page panel, persist the OFF state, and gray the toolbar icon.
+    // in-page panel, persist the OFF state, and gray the toolbar icon. `host` is passed
+    // when known (from the popout record) so we don't depend on reading the tab's url.
     browser.tabs.sendMessage(tabId, { action: "dpdReset" }).catch(() => {});
     browser.tabs.sendMessage(tabId, "destroy").catch(() => {});
     try {
-      const tab = await browser.tabs.get(tabId);
-      if (tab.url) {
-        const host = new URL(tab.url).hostname;
-        await browser.storage.local.set({ [`state_${host}`]: "OFF" });
+      let h = host;
+      if (!h) {
+        const tab = await browser.tabs.get(tabId);
+        if (tab.url) h = new URL(tab.url).hostname;
       }
+      if (h) await browser.storage.local.set({ [`state_${h}`]: "OFF" });
     } catch (e) {
       console.warn("[DPD] dismissOnTab failed to set OFF state:", e);
     }
@@ -182,14 +241,20 @@ export default defineBackground(() => {
     const winKey = `popout_win_${winId}`;
     const pinKey = `popout_pin_${winId}`;
     const rec = await browser.storage.session.get([winKey, pinKey]) as LocalStorage;
-    const tabId = rec[winKey];
-    if (tabId == null) return;
+    const info = rec[winKey] as { host: string; tab: number } | undefined;
+    if (info == null) return;
+    const { host, tab: tabId } = info;
     const wasPopIn = !!rec[pinKey];
     await browser.storage.session.remove([winKey, pinKey]);
     if (wasPopIn) {
+      // Restore the in-page panel on EVERY tab of this site (they watch popout_host_*).
+      await browser.storage.local.remove(`popout_host_${host}`);
       browser.tabs.sendMessage(tabId, { action: "dpdShowPanel" }).catch(() => {});
     } else {
-      await dismissOnTab(tabId);
+      // Turn DPD off across the whole site: set OFF first (all tabs tear down via the
+      // state_* watcher), THEN clear the popout flag so nothing briefly un-hides.
+      await dismissOnTab(tabId, host);
+      await browser.storage.local.remove(`popout_host_${host}`);
     }
   });
 });

--- a/exporter/wxt_extension/entrypoints/content.ts
+++ b/exporter/wxt_extension/entrypoints/content.ts
@@ -20,14 +20,14 @@ export default defineContentScript({
     let poppedOut = false; // true while the dictionary lives in its own popout window
     let themeObserver: MutationObserver | null = null;
     let themeDebounce: ReturnType<typeof setTimeout> | null = null;
-    let myTabId: number | null = null; // this tab's id, learned from the "started" reply
 
     // Define handleSelectedWord globally so utils and panel can call it
     (window as any).handleSelectedWord = async (word: string) => {
-      // While popped out, route selections to the popout window instead of the
-      // (now hidden) in-page panel.
+      // While popped out, route selections to this site's popout window instead of the
+      // (now hidden) in-page panel. Tagged with the hostname so the popout accepts
+      // selections from any tab of its own site and ignores other sites' popouts.
       if (poppedOut) {
-        browser.runtime.sendMessage({ action: "popoutSearch", q: word, tab: myTabId }).catch(() => {});
+        browser.runtime.sendMessage({ action: "popoutSearch", q: word, host: window.location.hostname }).catch(() => {});
         return;
       }
 
@@ -184,7 +184,10 @@ export default defineContentScript({
       browser.runtime
         .sendMessage({ action: "started" })
         .then((r: any) => {
-          if (r?.tabId != null) myTabId = r.tabId;
+          // This site already has an open popout (we navigated/opened a tab into it
+          // while popped out): hide the freshly-created in-page panel so the two don't
+          // coexist. Background validated the popout window is still live.
+          if (r?.poppedOut) setPoppedOut(true);
         })
         .catch(() => {});
 
@@ -231,23 +234,25 @@ export default defineContentScript({
       });
     }
 
+    function teardown() {
+      document.documentElement.classList.remove("dpd-active");
+      document.documentElement.classList.remove("dpd-popped-out");
+      document.body.classList.remove("dpd-active");
+      themeObserver?.disconnect();
+      themeObserver = null;
+      if (themeDebounce) {
+        clearTimeout(themeDebounce);
+        themeDebounce = null;
+      }
+      panel?.destroy();
+      panel = null;
+      poppedOut = false;
+      removeListenersFromTextElements();
+    }
+
     browser.runtime.onMessage.addListener((request: any) => {
       if (request === "init") init();
-      if (request === "destroy") {
-        document.documentElement.classList.remove("dpd-active");
-        document.documentElement.classList.remove("dpd-popped-out");
-        document.body.classList.remove("dpd-active");
-        themeObserver?.disconnect();
-        themeObserver = null;
-        if (themeDebounce) {
-          clearTimeout(themeDebounce);
-          themeDebounce = null;
-        }
-        panel?.destroy();
-        panel = null;
-        poppedOut = false;
-        removeListenersFromTextElements();
-      }
+      if (request === "destroy") teardown();
       // Popout coordination messages (objects; the core sends plain strings above).
       if (request && typeof request === "object") {
         if (request.action === "dpdHidePanel") setPoppedOut(true);
@@ -261,6 +266,20 @@ export default defineContentScript({
     });
 
     const hostname = window.location.hostname;
+
+    // Stay consistent with the background and with DPD in OTHER tabs of this same site.
+    // storage.local change events reach content scripts (session-storage ones do not), so
+    // this is what keeps EVERY open tab of a site in sync, not just the active/source one:
+    //   • popout_host_<host> set/cleared → hide/show this tab's in-page panel, so a
+    //     sibling tab can't sit there showing its panel while the site is popped out;
+    //   • state_<host> → OFF tears the panel down everywhere the site is open.
+    browser.storage.onChanged.addListener((changes: any, area: string) => {
+      if (area !== "local") return;
+      const stateChange = changes[`state_${hostname}`];
+      if (stateChange && stateChange.newValue === "OFF") { teardown(); return; }
+      const popoutChange = changes[`popout_host_${hostname}`];
+      if (popoutChange && panel) setPoppedOut(popoutChange.newValue != null);
+    });
 
     browser.storage.local.get(`state_${hostname}`).then((data) => {
       const savedState = data[`state_${hostname}`];

--- a/exporter/wxt_extension/entrypoints/popout/main.ts
+++ b/exporter/wxt_extension/entrypoints/popout/main.ts
@@ -10,9 +10,22 @@ import { DictionaryPanel } from '@/components/dictionary-panel';
 import { applyTheme } from '@/utils/themes';
 import { addListenersToTextElements, cleanWord } from '@/utils/utils';
 
+// Dropping a draggable (a link/button dragged from the source page, say) onto this
+// window would otherwise trigger the browser's default "navigate to the dropped URL"
+// behaviour — turning the popout into an ordinary https page, where the content script
+// then runs and spawns its OWN in-page panel, leaving two DPDs and desynced state.
+// Swallow drops that don't land on a text input (where inserting text is expected UX).
+function isTextTarget(t: EventTarget | null): boolean {
+  const el = t as HTMLElement | null;
+  return !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || !!el.closest?.('.dpd-search-box'));
+}
+for (const type of ['dragover', 'drop'] as const) {
+  window.addEventListener(type, (e) => { if (!isTextTarget(e.target)) e.preventDefault(); });
+}
+
 const params = new URLSearchParams(location.search);
 const initialQuery = params.get('q') || '';
-const sourceTab = params.get('tab') || ''; // the tab this popout was detached from
+const sourceHost = params.get('host') || ''; // the site this popout serves
 // The source page resolves its live theme to a concrete key (e.g. "s4nt_dark") and
 // passes it here, so the popout reproduces it with applyTheme(key) — no DOM guessing.
 // A bare "auto" (unrecognised source site) falls back to detecting the popout's own bg.
@@ -114,12 +127,12 @@ addListenersToTextElements();
 
 if (initialQuery) (window as any).handleSelectedWord(initialQuery);
 
-// Words selected on the originating page (while popped out) are forwarded here.
-// popoutSearch is a broadcast, so ignore selections from any tab other than our own
-// (prevents crosstalk when two tabs are popped out at once).
+// Words selected on any tab of this site (while popped out) are forwarded here.
+// popoutSearch is a broadcast, so ignore selections tagged with a different host
+// (prevents crosstalk when two different sites are popped out at once).
 browser.runtime.onMessage.addListener((msg: any) => {
   if (msg && typeof msg === 'object' && msg.action === 'popoutSearch') {
-    if (sourceTab && msg.tab != null && String(msg.tab) !== sourceTab) return;
+    if (sourceHost && msg.host && msg.host !== sourceHost) return;
     (window as any).handleSelectedWord(msg.q);
   }
 });


### PR DESCRIPTION
Part of #253.

## Problem

On multi-page sites (found on [s.4nt.org](https://s.4nt.org), which navigates between many pages) the popout and the in-page panel could both be active at once, extra popouts could breed, and the toolbar toggle looked like it did nothing. Root cause: popout state was ephemeral — held in the content script's memory and later keyed by tab id — so navigations, closing+reopening a tab, and sibling tabs all lost track of whether the site was popped out.

## Fix — popout ownership keyed by **site (hostname)**, with a single shared source of truth

- **One popout per site**, keyed on hostname (not tab id, which is ephemeral) and validated with `windows.get` so a stale flag can't wrongly hide a panel or block a new popout. Closing and reopening a site's tab no longer breeds duplicate popouts; a repeat pop-out just focuses the existing window.
- **All tabs of a site stay in sync.** `popout_host_<host>` lives in `storage.local` and every content script watches `storage.onChanged` (content scripts receive local-area change events; session-area ones they don't). So popping out hides the in-page panel on *every* open tab of the site, not just the source — no more popout + in-page panel side by side.
- **Dismiss propagates.** `state_<host> → OFF` tears the panel down on every open tab; closing the popout via its **X** now turns the site off everywhere, not just on the source tab.
- **Toolbar toggle on a popped-out site focuses the popout** instead of a no-visible-effect toggle (the in-page panel is intentionally hidden while popped out).
- **Popout swallows external drag-drops** (text inputs excepted): dropping a link/button onto the popout no longer navigates that window into an `https` page that then spawns its own in-page DPD.
- **Selection forwarding keyed by host**, so double-clicks from any tab of a site reach that site's one popout.

## Scope / notes

- Touches only `entrypoints/{content,background,popout/main}.ts`. No new permissions (uses `storage.local` change events rather than the `tabs` permission for cross-tab sync).
- Known minor asymmetry left intentional: turning DPD **on** via the toolbar affects the clicked tab; other already-open tabs of that site pick it up on next reload (turning **off** propagates immediately, since that's the dismiss path).
- Built with `npm run build:chrome` and manually verified on s.4nt.org: navigation while popped out, tab close+reopen, two tabs open, pop-in/dismiss, toolbar focus, and drag-into-popout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
