### PR TITLE
feat(extension): announce presence to the host page for site-side detection

### DIFF
--- a/exporter/wxt_extension/entrypoints/content.ts
+++ b/exporter/wxt_extension/entrypoints/content.ts
@@ -16,6 +16,19 @@ export default defineContentScript({
   matches: ['<all_urls>'],
   runAt: 'document_end',
   main() {
+    // Announce our presence to the host page, UNCONDITIONALLY — before the per-domain
+    // ON/OFF gate below — so any site can detect that DPD is installed even when it is
+    // not enabled for that domain. This is how a site (e.g. s.4nt.org) can decide whether
+    // to show a "get DPD" badge without hardcoding the extension id or probing a resource,
+    // and it works on Firefox too. We set a persistent attribute (so a page that checks
+    // after our document_end run still sees it) AND fire a one-shot event (for listeners
+    // attached early). The marker reflects *installed*, not *active*, so it is never removed.
+    try {
+      const version = browser.runtime.getManifest().version;
+      document.documentElement.dataset.dpd = version;
+      window.dispatchEvent(new CustomEvent("dpd:present", { detail: { version } }));
+    } catch (e) { /* getManifest can throw if the context is torn down; ignore */ }
+
     let panel: DictionaryPanel | null = null;
     let poppedOut = false; // true while the dictionary lives in its own popout window
     let themeObserver: MutationObserver | null = null;


### PR DESCRIPTION
## Why

You asked how a site like [s.4nt.org](https://s.4nt.org) could show a "get DPD" badge only to visitors who don't already have the extension. The existing signals don't cleanly answer *"is DPD installed?"*:

- **`dpd-active` class** is set in `init()`, which is gated by `AUTO_DOMAINS` / the per-site toggle — so it only tells you DPD is *active on this domain*, not whether it's *installed* (a user with DPD installed but disabled for the site looks identical to not having it).
- **Probing a `web_accessible_resource` by id** works, but only on Chromium (Firefox's internal id is a random per-install UUID) and hardcodes the store id (misses sideloaded builds).

## What

Announce presence to the host page **unconditionally, before the per-domain ON/OFF gate**, so any site can detect DPD regardless of whether it's enabled there, with no hardcoded id, and on Firefox too:

```ts
document.documentElement.dataset.dpd = version;                          // persistent marker
window.dispatchEvent(new CustomEvent('dpd:present', { detail: { version } }));  // for early listeners
```

The attribute covers pages that check *after* our `document_end` run; the event covers pages listening early. The marker reflects **installed**, not **active**, so it is never removed on `destroy`.

A site then does:

```js
if (document.documentElement.dataset.dpd) hideBadge();
else addEventListener('dpd:present', () => hideBadge());
```

## Notes

- One file (`entrypoints/content.ts`), ~6 lines, no new permissions, no behavior change to the panel/popout.
- Exposes only the version string — no capabilities granted to the page.
- Naming (`data-dpd` / `dpd:present`) is easy to change if you'd prefer something else.
- Built with `npm run build:chrome` and verified: `document.documentElement.dataset.dpd` returns the version on a page where DPD is not active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)